### PR TITLE
Fixed issue with map loading in incorrect order

### DIFF
--- a/game.py
+++ b/game.py
@@ -19,7 +19,7 @@ class Game:
 		self.bg = (255,255,255)
 
 		#Load all maps into a map array
-		self.maps = glob.glob('./maps/*.txt')
+		self.maps = sorted(glob.glob('./maps/*.txt'))
 		#Set the level to 0
 		self.level = 0
 


### PR DESCRIPTION
Turns out that python's glob module doesn't guarantee to find wildcards lexicographically - it usually finds them by their place in the filesystem, which isn't always the same. Anyway, it's fixed now.